### PR TITLE
Option for custom data function and more flexible AutoForm submission

### DIFF
--- a/wizard.js
+++ b/wizard.js
@@ -1,29 +1,20 @@
-var wizardsById = {};
-var defaultId = '_defaultId';
-
 Template.wizard.created = function() {
-  var id = this.data.id || defaultId;
-  wizardsById[id] = new Wizard(this);
+  this.wizard = new Wizard(this);
 };
 
 Template.wizard.destroyed = function() {
-  var id = this.data.id || defaultId;
-
-  if (wizardsById[id]) {
-    wizardsById[id].destroy();
-    delete wizardsById[id];
-  }
+  this.wizard && this.wizard.destroy();
 };
 
 Template.wizard.helpers({
   innerContext: function(outerContext) {
-    var context = this
-      , wizard = wizardsById[this.id]
+    var instance = Template.instance()
+      , wizard = instance.wizard
       , activeStep = wizard.activeStep();
 
     var innerContext = {
       data: activeStep && activeStep.data,
-      wizard: wizardsById[this.id],
+      wizard: wizard,
       stepsTemplate: this.stepsTemplate || 'wizardSteps'
     };
 
@@ -37,7 +28,7 @@ Template.wizard.helpers({
 });
 
 Template.wizardSteps.helpers({
-  activeStepClass: function(id) { 
+  activeStepClass: function(id) {
     var activeStep = this.wizard.activeStep();
     return (activeStep && activeStep.id == id) && 'active' || '';
   }
@@ -46,33 +37,36 @@ Template.wizardSteps.helpers({
 var Wizard = function(template) {
   this._dep = new Tracker.Dependency();
   this.template = template;
-  
+  this.useCache = template.data.useCache !== false;
+
   _.extend(this, _.pick(template.data, [
     'id', 'route', 'steps', 'clearOnDestroy'
   ]));
 
   this._stepsByIndex = [];
   this._stepsById = {};
-  
-  this.store = new CacheStore(this.id, {
-    persist: template.data.persist !== false,
-    expires: template.data.expires || null
-  });
-  
+
+  if (this.useCache) {
+    this.store = new CacheStore(this.id, {
+      persist: template.data.persist !== false,
+      expires: template.data.expires || null
+    });
+  }
+
   this.initialize();
 };
 
 Wizard.prototype = {
-  
+
   constructor: Wizard,
 
   initialize: function() {
     var self = this;
-    
+
     _.each(this.steps, function(step) {
       self._initStep(step);
     });
-    
+
     Deps.autorun(function() {
       self._setActiveStep();
     });
@@ -80,27 +74,37 @@ Wizard.prototype = {
 
   _initStep: function(step) {
     var self = this;
-    
+
     if(!step.id) {
       throw new Error('Step.id is required');
     }
-    
+
     if(!step.formId) {
       throw new Error('Step.formId is required');
     }
-    
-    this._stepsByIndex.push(step.id);
-    this._stepsById[step.id] = _.extend(step, {
-      wizard: self,
-      data: function() {
-        return self.store.get(step.id);
-      }
-    });
+
+    (function (template) {
+      var useCustom = !self.useCache && _.isFunction(template.data);
+      var defaultData = function () { // default data function
+        return self.store && self.store.get(step.id);
+      };
+      var customData = function () { // custom data function
+        return template.data(step.id);
+      };
+
+      self._stepsByIndex.push(step.id);
+      self._stepsById[step.id] = _.defaults(step, {
+        wizard: self,
+        // use custom data function if not using cache
+        data: useCustom ? customData : defaultData
+      });
+    })(self.template.data);
+
 
     AutoForm.addHooks([step.formId], {
       onSubmit: function(data) {
         if(step.onSubmit) {
-          step.onSubmit.call(this, data, self);
+          step.onSubmit.call(this, data, self, step);
         } else {
           self.next(data);
         }
@@ -108,7 +112,7 @@ Wizard.prototype = {
       }
     }, true);
   },
-  
+
   _setActiveStep: function() {
     // show the first step if not bound to a route
     if(!this.route) {
@@ -116,35 +120,35 @@ Wizard.prototype = {
     }
 
     var current = Router.current();
-    
+
     if(!current || (current && current.route.getName() != this.route)) return false;
-    
+
     var params = current.params
       , index = _.indexOf(this._stepsByIndex, params.step)
       , previousStep = this.getStep(index - 1);
 
     // initial route or non existing step, redirect to first step
-    if(!params.step || index === -1) {
-      return this.show(0);
-    }
+      if(!params.step || index === -1) {
+        return this.show(0);
+      }
 
-    // invalid step
-    if(index > 0 && previousStep && !previousStep.data()) {
-      return this.show(0);
-    }
+      // invalid step
+      if(index > 0 && previousStep && !previousStep.data()) {
+        return this.show(0);
+      }
 
-    // valid
-    this.setStep(params.step);
+      // valid
+      this.setStep(params.step);
   },
-  
+
   setData: function(id, data) {
-    this.store.set(id, data);
+    this.store && this.store.set(id, data);
   },
-  
+
   clearData: function() {
-    this.store.clear();
+    this.store && this.store.clear();
   },
-  
+
   mergedData: function() {
     var data = {}
     _.each(this._stepsById, function(step) {
@@ -152,28 +156,32 @@ Wizard.prototype = {
     });
     return data;
   },
-  
+
   next: function(data) {
     var activeIndex = _.indexOf(this._stepsByIndex, this._activeStepId);
-    
-    this.setData(this._activeStepId, data);
-    
+
+    if (this.useCache) {
+      this.setData(this._activeStepId, data);
+    }
+
     this.show(activeIndex + 1);
   },
-  
+
   previous: function() {
     var activeIndex = _.indexOf(this._stepsByIndex, this._activeStepId);
 
-    this.setData(this._activeStepId, AutoForm.getFormValues(this.activeStep(false).formId));
-    
+    if (this.useCache) {
+      this.setData(this._activeStepId, AutoForm.getFormValues(this.activeStep(false).formId));
+    }
+
     this.show(activeIndex - 1);
   },
-  
+
   show: function(id) {
     if(typeof id === 'number') {
       id = id in this._stepsByIndex && this._stepsByIndex[id];
     }
-    
+
     if(!id) return false;
 
     if(this.route) {
@@ -181,36 +189,36 @@ Wizard.prototype = {
     } else {
       this.setStep(id);
     }
-    
+
     return true;
   },
-  
+
   getStep: function(id) {
     if(typeof id === 'number') {
       id = id in this._stepsByIndex && this._stepsByIndex[id];
     }
-    
+
     return id in this._stepsById && this._stepsById[id];
   },
-  
+
   activeStep: function(reactive) {
     if(reactive !== false) {
       this._dep.depend();
     }
     return this._stepsById[this._activeStepId];
   },
-  
+
   setStep: function(id) {
     this._activeStepId = id;
     this._dep.changed();
     return this._stepsById[this._activeStepId];
   },
-  
+
   indexOf: function(id) {
     return _.indexOf(this._stepsByIndex, id);
   },
-  
+
   destroy: function() {
-    if(this.clearOnDestroy) this.clearData();
-  } 
+    if(this.useCache && this.clearOnDestroy) this.clearData();
+  }
 };

--- a/wizard.js
+++ b/wizard.js
@@ -4,6 +4,7 @@ Template.wizard.created = function() {
 
 Template.wizard.destroyed = function() {
   this.wizard && this.wizard.destroy();
+  this.wizard = null;
 };
 
 Template.wizard.helpers({
@@ -99,17 +100,37 @@ Wizard.prototype = {
       });
     })(self.template.data);
 
-
     AutoForm.addHooks([step.formId], {
-      onSubmit: function(data) {
+      onSubmit: function(insertDoc, updateDoc, currentDoc) {
         if(step.onSubmit) {
-          step.onSubmit.call(this, data, self);
+          step.onSubmit.call(this, insertDoc, updateDoc, currentDoc, self);
         } else {
-          self.next(data);
+          this.done();
+          self.next(insertDoc);
         }
         return false;
+      },
+      onSuccess: function(operation, result, template) {
+        if(step.onSuccess) {
+          step.onSuccess.call(this, operation, result, template, self);
+        }
+      },
+      onError: function(operation, error, template) {
+        if(step.onError) {
+          step.onError.call(this, operation, error, template, self);
+        }
+      },
+      beginSubmit: function(formId, template) {
+        if(step.beginSubmit) {
+          step.beginSubmit.call(this, formId, template, self);
+        }
+      },
+      endSubmit: function(formId, template) {
+        if(step.endSubmit) {
+          step.endSubmit.call(this, formId, template, self);
+        }
       }
-    }, true);
+    });
   },
 
   _setActiveStep: function() {


### PR DESCRIPTION
I'm not sure if these additions stray too far from what you intended with this package (i.e a very simple, minimal-configuration wizard), so if you do find it so, please feel free to close this PR :)

For my use case though, I didn't want to use the cache store for certain wizards because the data needed to be persisted in a collection rather than amplify/local cache. So what happened was, if the page were closed and revisited, the wizard started from the beginning because the local data didn't exist. What I wanted was for the wizard to read from the collection instead, and to remember where in the process we last left. 

I'm not entirely sure why the only AutoForm hook provided was `onSubmit`. I find it useful to be able to use hooks like `beginSubmit` and `onSuccess`, for instance to make it easier to show loading messages or call `wizard.next()` when dealing with some async stuff/method calls. 

Also, I'm not entirely sure what the reasoning behind the `wizardsById` object was for. Please correct me if I'm wrong, but you can just store the wizard instance within the template instance, right? Am I missing something?