### PR TITLE
Adapted to autoform 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ meteor add forwarder:autoform-wizard
 
 ## Dependencies
 
-* AutoForm versions 3 or 4.
+* AutoForm versions 5 (for version 4 or earlier use version 0.4.2 of this package)
 * Iron Router support is optional, works with version 1.
 
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'forwarder:autoform-wizard',
   summary: 'A multi step form component for AutoForm.',
-  version: '0.4.2',
+  version: '0.5.0',
   git: 'https://github.com/forwarder/meteor-wizard.git'
 });
 
@@ -18,7 +18,7 @@ Package.onUse(function(api) {
     'localstorage'
   ], 'client');
   
-  api.use('aldeed:autoform@3.0.0 || 4.0.0', 'client');
+  api.use('aldeed:autoform@5.0.0', 'client');
   
   api.addFiles([
     'wizard.html',

--- a/versions.json
+++ b/versions.json
@@ -2,7 +2,7 @@
   "dependencies": [
     [
       "aldeed:autoform",
-      "4.0.7"
+      "5.0.2"
     ],
     [
       "aldeed:simple-schema",

--- a/wizard.html
+++ b/wizard.html
@@ -27,7 +27,7 @@
   <div class="wizard-step">
     {{#autoForm id=formId doc=data schema=schema}}
       {{#each afFieldNames}}
-        {{> afQuickField name=this options="auto"}}
+        {{> afQuickField }}
       {{/each}}
       {{> __wizard_nav}}
     {{/autoForm}}


### PR DESCRIPTION
This required to change the wizard.html  because `afFieldNames` do not
longer return an array of names but instead an array of objects