### PR TITLE
Save initial data

### DIFF
--- a/wizard.js
+++ b/wizard.js
@@ -7,7 +7,10 @@ Wizard.get = function(id) {
   return wizardsById[id || defaultId];
 };
 
-Wizard.stepTemplate = '__wizard_step';
+Wizard.extendOptions = function(options, defaults) {
+  _options = _options.concat(options);
+  _.extend(_defaults, defaults);
+};
 
 Template.registerHelper('pathForStep', function(id) {
   var activeStep = this.wizard.activeStep(false);
@@ -103,30 +106,33 @@ Template.wizardButtons.helpers({
   }
 });
 
-var WizardConstructor = function(options) {
-  this._dep = new Tracker.Dependency();
+var _options = [
+  'id',
+  'route',
+  'steps',
+  'stepsTemplate',
+  'stepTemplate',
+  'buttonClasses',
+  'nextButton',
+  'backButton',
+  'confirmButton',
+  'persist',
+  'clearOnDestroy'
+];
 
-  options = _.chain(options).pick(
-    'id',
-    'route',
-    'steps',
-    'stepsTemplate',
-    'stepTemplate',
-    'buttonClasses',
-    'nextButton',
-    'backButton',
-    'confirmButton',
-    'persist',
-    'clearOnDestroy'
-  ).defaults({
+var _defaults = {
     stepsTemplate: '__wizard_steps',
     stepTemplate: '__wizard_step',
     nextButton: 'Next',
     backButton: 'Back',
     confirmButton: 'Confirm',
     persist: true
-  }).value();
+}
 
+var WizardConstructor = function(options) {
+  this._dep = new Tracker.Dependency();
+
+  options = _.chain(options).pick(_options).defaults(_defaults).value();
   _.extend(this, options);
 
   this._stepsByIndex = [];
@@ -317,3 +323,5 @@ WizardConstructor.prototype = {
     if(this.clearOnDestroy) this.clearData();
   }
 };
+
+Wizard.WizardConstructor = WizardConstructor;

--- a/wizard.js
+++ b/wizard.js
@@ -7,6 +7,8 @@ Wizard.get = function(id) {
   return wizardsById[id || defaultId];
 };
 
+Wizard.stepTemplate = '__wizard_step';
+
 Template.registerHelper('pathForStep', function(id) {
   var activeStep = this.wizard.activeStep(false);
   if (activeStep.id === id || !this.data() || this.wizard.indexOf(id) > this.wizard.indexOf(activeStep.id)) {
@@ -14,7 +16,7 @@ Template.registerHelper('pathForStep', function(id) {
   } if (!this.wizard.route) {
     return '#' + id;
   }
-  
+
   return WizardRouter.path(this.wizard.route, id);
 });
 
@@ -44,7 +46,7 @@ Template.wizard.helpers({
   },
   activeStepTemplate: function() {
     var activeStep = this.wizard.activeStep();
-    return activeStep && (activeStep.template || '__wizard_step') || null;
+    return activeStep && (activeStep.template || Wizard.stepTemplate) || null;
   }
 });
 
@@ -58,7 +60,7 @@ Template.__wizard_steps.events({
 });
 
 Template.__wizard_steps.helpers({
-  activeStepClass: function(id) { 
+  activeStepClass: function(id) {
     var activeStep = this.wizard.activeStep();
     return (activeStep && activeStep.id == id) && 'active' || '';
   }
@@ -67,14 +69,14 @@ Template.__wizard_steps.helpers({
 // Temporary fix because AutoForm doesnt support reactive schema's
 Template.__wizard_step.created = function() {
   var self = this;
-  
+
   this.destroyForm = new ReactiveVar(false);
-  
+
   this.autorun(function() {
     var data = Blaze.getData();
     self.destroyForm.set(true);
   });
-  
+
   this.autorun(function () {
     if (self.destroyForm.get()) {
       self.destroyForm.set(false);
@@ -103,7 +105,7 @@ Template.wizardButtons.helpers({
 
 var WizardConstructor = function(options) {
   this._dep = new Tracker.Dependency();
-  
+
   options = _.chain(options).pick(
     'id',
     'route',
@@ -122,26 +124,26 @@ var WizardConstructor = function(options) {
     confirmButton: 'Confirm',
     persist: true
   }).value();
-  
+
   _.extend(this, options);
-  
+
   this._stepsByIndex = [];
   this._stepsById = {};
-  
+
   this.store = new CacheStore(this.id, {
     persist: this.persist !== false
   });
-  
+
   this.initialize();
 };
 
 WizardConstructor.prototype = {
-  
+
   constructor: WizardConstructor,
 
   initialize: function() {
     var self = this;
-    
+
     _.each(this.steps, function(step) {
       self._initStep(step);
     });
@@ -157,15 +159,15 @@ WizardConstructor.prototype = {
 
   _initStep: function(step) {
     var self = this;
-    
+
     if (!step.id) {
       throw new Meteor.Error('step-id-required', 'Step.id is required');
     }
-    
+
     if (!step.formId) {
       step.formId = step.id + '-form';
     }
-    
+
     this._stepsByIndex.push(step.id);
     this._stepsById[step.id] = _.extend(step, {
       wizard: self,
@@ -177,7 +179,7 @@ WizardConstructor.prototype = {
     AutoForm.addHooks(step.formId, {
       onSubmit: function(data) {
         this.event.preventDefault();
-        
+
         if(step.onSubmit) {
           step.onSubmit.call(this, data, self);
         } else {
@@ -186,7 +188,7 @@ WizardConstructor.prototype = {
       }
     }, true);
   },
-  
+
   _setActiveStep: function(step) {
     // show the first step if not bound to a route
     if(!step) {
@@ -200,7 +202,7 @@ WizardConstructor.prototype = {
     if(index === -1) {
       return this.setStep(0);
     }
-    
+
     // invalid step
     if(index > 0 && previousStep && !previousStep.data()) {
       return this.setStep(0);
@@ -209,15 +211,15 @@ WizardConstructor.prototype = {
     // valid
     this.setStep(step);
   },
-  
+
   setData: function(id, data) {
     this.store.set(id, data);
   },
-  
+
   clearData: function() {
     this.store.clear();
   },
-  
+
   mergedData: function() {
     var data = {};
     _.each(this._stepsById, function(step) {
@@ -225,15 +227,15 @@ WizardConstructor.prototype = {
     });
     return data;
   },
-  
+
   next: function(data) {
     var activeIndex = _.indexOf(this._stepsByIndex, this._activeStepId);
-    
+
     this.setData(this._activeStepId, data);
 
     this.show(activeIndex + 1);
   },
-  
+
   previous: function() {
     var activeIndex = _.indexOf(this._stepsByIndex, this._activeStepId);
 
@@ -241,7 +243,7 @@ WizardConstructor.prototype = {
 
     this.show(activeIndex - 1);
   },
-  
+
   show: function(id) {
     if(typeof id === 'number') {
       id = id in this._stepsByIndex && this._stepsByIndex[id];
@@ -257,55 +259,55 @@ WizardConstructor.prototype = {
 
     return true;
   },
-  
+
   getStep: function(id) {
     if(typeof id === 'number') {
       id = id in this._stepsByIndex && this._stepsByIndex[id];
     }
-    
+
     return id in this._stepsById && this._stepsById[id];
   },
-  
+
   activeStep: function(reactive) {
     if(reactive !== false) {
       this._dep.depend();
     }
     return this._stepsById[this._activeStepId];
   },
-  
+
   setStep: function(id) {
     if(typeof id === 'number') {
       id = id in this._stepsByIndex && this._stepsByIndex[id];
     }
 
     if(!id) return false;
-    
+
     this._activeStepId = id;
     this._dep.changed();
     return this._stepsById[this._activeStepId];
   },
-  
+
   isActiveStep: function(id) {
     return id === this._activeStepId;
   },
-  
+
   isFirstStep: function(id) {
     id = id || this._activeStepId;
     return this.indexOf(id) === 0;
   },
-  
+
   isLastStep: function(id) {
     id = id || this._activeStepId;
     return this.indexOf(id) === this._stepsByIndex.length - 1;
   },
-  
+
   indexOf: function(id) {
     return _.indexOf(this._stepsByIndex, id);
   },
-  
+
   destroy: function() {
     this._comp.stop();
-    
+
     if(this.clearOnDestroy) this.clearData();
-  } 
+  }
 };

--- a/wizard.js
+++ b/wizard.js
@@ -170,6 +170,10 @@ WizardConstructor.prototype = {
       step.formId = step.id + '-form';
     }
 
+    if (step.data) {
+      this.setData(step.id, step.data);
+    }
+
     this._stepsByIndex.push(step.id);
     this._stepsById[step.id] = _.extend(step, {
       wizard: self,

--- a/wizard.js
+++ b/wizard.js
@@ -96,7 +96,7 @@ Template.__wizard_step.helpers({
 Template.wizardButtons.events({
   'click .wizard-back-button': function(e) {
     e.preventDefault();
-    this.previous();
+    this.previous(AutoForm.getFormValues(this.activeStep(false).formId));
   }
 });
 
@@ -243,15 +243,19 @@ WizardConstructor.prototype = {
   next: function(data) {
     var activeIndex = _.indexOf(this._stepsByIndex, this._activeStepId);
 
-    this.setData(this._activeStepId, data);
+    if(data) {
+      this.setData(this._activeStepId, data);
+    }
 
     this.show(activeIndex + 1);
   },
 
-  previous: function() {
+  previous: function(data) {
     var activeIndex = _.indexOf(this._stepsByIndex, this._activeStepId);
 
-    this.setData(this._activeStepId, AutoForm.getFormValues(this.activeStep(false).formId));
+    if(data) {
+     this.setData(this._activeStepId, data);
+    }
 
     this.show(activeIndex - 1);
   },

--- a/wizard.js
+++ b/wizard.js
@@ -46,7 +46,7 @@ Template.wizard.helpers({
   },
   activeStepTemplate: function() {
     var activeStep = this.wizard.activeStep();
-    return activeStep && (activeStep.template || Wizard.stepTemplate) || null;
+    return activeStep && (activeStep.template || this.wizard.stepTemplate) || null;
   }
 });
 
@@ -111,6 +111,7 @@ var WizardConstructor = function(options) {
     'route',
     'steps',
     'stepsTemplate',
+    'stepTemplate',
     'buttonClasses',
     'nextButton',
     'backButton',
@@ -119,6 +120,7 @@ var WizardConstructor = function(options) {
     'clearOnDestroy'
   ).defaults({
     stepsTemplate: '__wizard_steps',
+    stepTemplate: '__wizard_step',
     nextButton: 'Next',
     backButton: 'Back',
     confirmButton: 'Confirm',


### PR DESCRIPTION
In order to support update or 'on place edit' initial `data` provide on `step`object must be save on cache before _initStep method set `data` property
This PR is based on same brach of https://github.com/forwarder/meteor-wizard/pull/41 and https://github.com/forwarder/meteor-wizard/pull/38
Maybe the above must be merge first.
@Pagebakers please review this. I'm working over incremental changes. Don´t know is my changed get approved ...
Thanks
