### PR TITLE
expose WizardRouter

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'forwarder:autoform-wizard',
   summary: 'A multi step form component for AutoForm.',
-  version: '0.8.0',
+  version: '0.8.1',
   git: 'https://github.com/forwarder/meteor-wizard.git'
 });
 
@@ -29,5 +29,8 @@ Package.onUse(function(api) {
   ], 'client');
 
   if (api.export)
-    api.export('Wizard', 'client');
+    api.export([
+      'Wizard',
+      'WizardRouter'
+    ], 'client');
 });

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'forwarder:autoform-wizard',
   summary: 'A multi step form component for AutoForm.',
-  version: '0.8.1',
+  version: '0.8.2',
   git: 'https://github.com/forwarder/meteor-wizard.git'
 });
 

--- a/router.js
+++ b/router.js
@@ -2,6 +2,7 @@ var routers = {}, activeRouter = 'default';
 
 var defaultConfig = {
   go: function(name, stepId) {},
+  reload: function(name, stepId) {},
   getParams: function(stepId) {},
   getStep: function() {},
   path: function(name, stepId) {
@@ -16,6 +17,9 @@ WizardRouter = {
   },
   go: function() {
     return this.apply('go', arguments);
+  },
+  reload: function() {
+    return this.apply('reload', arguments);
   },
   getParams: function() {
     return this.apply('getParams', arguments);


### PR DESCRIPTION
@Pagebakers review this PR please.
In order to customize router behaviour `WizardRouter` must be expose.

by the way I rewrite meteor-wizard-example using FlowRouter and Bootstrap. Is here: https://github.com/bySabi/meteor-wizard-example-with-flowrouter-bootstrap . Review too and copy paste on `meteor-wizard` project.