### PR TITLE
"Fix for previous button, overwriting step.data incorrectly"

### DIFF
--- a/wizard.js
+++ b/wizard.js
@@ -61,7 +61,7 @@ Template.__wizard_steps.helpers({
 Template.wizardButtons.events({
   'click .wizard-back-button': function(e) {
     e.preventDefault();
-    this.previous(AutoForm.getFormValues(this.activeStep(false).formId));
+    this.previous(this.activeStep().data());
   }
 });
 


### PR DESCRIPTION
Where in a multiple steps wizard would store the step.data as {insertDoc:{}, updateDoc:{}} instead of the actual value of the fields.